### PR TITLE
fixed infinity role reaction

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ roles_dict = {"1. Semester": '1️⃣'.encode('unicode-escape').decode('ASCII'),
               "AI": '🇦'.encode('unicode-escape').decode('ASCII'),
               "Bachelor": '🇧'.encode('unicode-escape').decode('ASCII'),
               "Master": '🇲'.encode('unicode-escape').decode('ASCII'),
-              "∞.Semester": '♾️'.encode('unicode-escape').decode('ASCII'),
+              "∞. Semester": '♾️'.encode('unicode-escape').decode('ASCII'),
               "PhD": '🥼'.encode('unicode-escape').decode('ASCII'),
               "Alumni": '🎓'.encode('unicode-escape').decode('ASCII'),
               "Informatik-Cafe": '🫖'.encode('unicode-escape').decode('ASCII'),
@@ -79,5 +79,3 @@ async def on_raw_reaction_remove(payload):
                 await member.remove_roles(role, atomic=True)
 
 bot.run(token)
-
-


### PR DESCRIPTION
Adding and removing the infinity semester role by the user themselves is currently broken (altering the reaction does not change the actual role state). This is probably due to a missing space in the role dict: '∞.Semester' -> '∞. Semester', which has been fixed in this pull request.